### PR TITLE
Add basic stats API.

### DIFF
--- a/server.conf.in
+++ b/server.conf.in
@@ -110,3 +110,8 @@ url =
 # information.
 # Leave empty to disable GeoIP lookups.
 #license =
+
+[stats]
+# Comma-separated list of IP addresses that are allowed to access the stats
+# endpoint. Leave empty (or commented) to only allow access from "127.0.0.1".
+#allowed_ips =

--- a/src/signaling/hub.go
+++ b/src/signaling/hub.go
@@ -1413,6 +1413,22 @@ func (h *Hub) processRoomParticipants(message *BackendServerRoomRequest) {
 	room.PublishUsersChanged(message.Participants.Changed, message.Participants.Users)
 }
 
+func (h *Hub) GetStats() map[string]interface{} {
+	result := make(map[string]interface{})
+	h.ru.RLock()
+	result["rooms"] = len(h.rooms)
+	h.ru.RUnlock()
+	h.mu.Lock()
+	result["sessions"] = len(h.sessions)
+	h.mu.Unlock()
+	if h.mcu != nil {
+		if stats := h.mcu.GetStats(); stats != nil {
+			result["mcu"] = stats
+		}
+	}
+	return result
+}
+
 func getRealUserIP(r *http.Request) string {
 	// Note this function assumes it is running behind a trusted proxy, so
 	// the headers can be trusted.

--- a/src/signaling/mcu_common.go
+++ b/src/signaling/mcu_common.go
@@ -45,6 +45,8 @@ type Mcu interface {
 	Start() error
 	Stop()
 
+	GetStats() interface{}
+
 	NewPublisher(ctx context.Context, listener McuListener, id string, streamType string) (McuPublisher, error)
 	NewSubscriber(ctx context.Context, listener McuListener, publisher string, streamType string) (McuSubscriber, error)
 }

--- a/src/signaling/mcu_test.go
+++ b/src/signaling/mcu_test.go
@@ -41,6 +41,10 @@ func (m *TestMCU) Start() error {
 func (m *TestMCU) Stop() {
 }
 
+func (m *TestMCU) GetStats() interface{} {
+	return nil
+}
+
 func (m *TestMCU) NewPublisher(ctx context.Context, listener McuListener, id string, streamType string) (McuPublisher, error) {
 	return nil, fmt.Errorf("Not implemented")
 }


### PR DESCRIPTION
Can be used to query number of sessions, rooms and (if Janus is configured),
overall MCU clients and publishers.